### PR TITLE
Exec code in another process to stop idiots like me redefining the Sinatra app.

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require 'stringio'
+
+result = exception = nil
+begin
+  real_stdout, $stdout = $stdout, StringIO.new
+  result = eval("$SAFE = 2; #{STDIN.read}")
+rescue Exception => e
+  exception = e
+end
+
+real_stdout.print Marshal.dump([result, $stdout.string, exception])


### PR DESCRIPTION
This is still quite breakable. Perhaps you can use JRuby on Heroku and use
someone else's sandbox implementation (https://github.com/omghax/jruby-sandbox)
to run code in a slightly safer manner.
- Adds a runner to execute given code in a separate process
- Changes Riddle to use the external code runner
